### PR TITLE
Feature/initial version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,3 +31,7 @@ workflows:
       - deploy:
           requires:
             - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+
+jobs:
+  deploy:
+    docker:
+      - image: jenkinsrise/cci-v2-docker-java8-gcloud:0.0.1
+    working_directory: ~/cors-filter
+
+    steps:
+      - checkout
+      - run: git config --global user.name $JENKINS_USERNAME
+      - run: git config --global user.email $JENKINS_EMAIL
+      - add_ssh_keys:
+          fingerprints:
+            - "3f:e3:b8:f5:9e:58:a8:e0:70:03:38:58:4f:62:9a:97"
+      - run: mvn deploy
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,11 @@ jobs:
       - checkout
       - run: git config --global user.name $JENKINS_USERNAME
       - run: git config --global user.email $JENKINS_EMAIL
-      - add_ssh_keys:
-          fingerprints:
-            - "3f:e3:b8:f5:9e:58:a8:e0:70:03:38:58:4f:62:9a:97"
+      - run: mkdir -p ~/.ssh
+      - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git clone git@github.com:Rise-Vision/private-keys.git
+      - run: cp private-keys/mvn-repo/mvn-repo-deploy-key* ~/.ssh/*
+      - run: cat ~/.ssh/mvn-repo-deploy-key.pub | tee -a ~/.ssh/authorized_keys
       - run: mvn deploy
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,17 @@
 version: 2
 
 jobs:
-  deploy:
-    docker:
+  test:
+    docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-docker-java8-gcloud:0.0.1
     working_directory: ~/cors-filter
+    steps:
+      - checkout
+      - run: mvn test
 
+  deploy:
+    docker: *BUILDIMAGE
+    working_directory: ~/cors-filter
     steps:
       - checkout
       - run: git config --global user.name $JENKINS_USERNAME
@@ -21,4 +27,7 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
+      - test
       - deploy
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: mkdir -p ~/.ssh
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone git@github.com:Rise-Vision/private-keys.git
-      - run: cp private-keys/mvn-repo/mvn-repo-deploy-key* ~/.ssh/*
+      - run: cp private-keys/mvn-repo/mvn-repo-deploy-key* ~/.ssh/
       - run: cat ~/.ssh/mvn-repo-deploy-key.pub | tee -a ~/.ssh/authorized_keys
       - run: mvn deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,6 @@ workflows:
   build_and_deploy:
     jobs:
       - test
-      - deploy
+      - deploy:
           requires:
             - test

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea
+*.iml
+/target/
+target/
+.settings/
+.classpath
+.project

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The HSTS Filter is a servlet filter used to add the [Strict-Transport-Security header](https://tools.ietf.org/html/draft-ietf-websec-strict-transport-sec-14#section-6.1) to HTTPS requests.
 
 ## Built With
-- Java (1.8) 
+- Java (1.8)
 - Maven
 - [Wagon-Git](https://github.com/synergian/wagon-git)
 - [Mockito](https://github.com/mockito/mockito)
@@ -23,12 +23,12 @@ mvn verify
 ```
 
 ### Dependencies
-* Junit for testing 
+* Junit for testing
 * Mockito for mocking and testing
 * Wagon-Git for releasing the artifacts to [Rise Vision Maven Repository](https://github.com/Rise-Vision/mvn-repo)
 
 ### Usage
-* Add CORS filter as dependency to your project 
+* Add CORS filter as dependency to your project
 
 ```xml
 
@@ -64,7 +64,7 @@ mvn verify
 <!-- In the <dependencies> section of your project's pom.xml -->
 <dependency>
   <!-- From our private repo -->
-  <groupId>com.risevision.cors</groupId>
+  <groupId>com.risevision.hsts</groupId>
   <artifactId>hsts-filter</artifactId>
   <version>1.0.0</version>
 </dependency>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,119 @@
-# hsts-filter
-Strict-Transport-Security Header Filter
+# HSTS Filter [![Circle CI](https://circleci.com/gh/Rise-Vision/hsts-filter.svg?style=svg)](https://circleci.com/gh/Rise-Vision/hsts-filter)
+
+## Introduction
+
+The HSTS Filter is a servlet filter used to add the [Strict-Transport-Security header](https://tools.ietf.org/html/draft-ietf-websec-strict-transport-sec-14#section-6.1) to HTTPS requests.
+
+## Built With
+- Java (1.8) 
+- Maven
+- [Wagon-Git](https://github.com/synergian/wagon-git)
+- [Mockito](https://github.com/mockito/mockito)
+
+## Development
+
+### Local Development Environment Setup and Installation
+
+* Maven 3 is required.
+
+* Local build / test
+``` bash
+mvn clean install
+mvn verify
+```
+
+### Dependencies
+* Junit for testing 
+* Mockito for mocking and testing
+* Wagon-Git for releasing the artifacts to [Rise Vision Maven Repository](https://github.com/Rise-Vision/mvn-repo)
+
+### Usage
+* Add CORS filter as dependency to your project 
+
+```xml
+
+<!-- Inside pom.xml of your project -->
+
+<repositories>
+  <repository>
+    <id>mvn-repo-releases</id>
+    <releases>
+      <enabled>true</enabled>
+    </releases>
+    <snapshots>
+      <enabled>false</enabled>
+    </snapshots>
+    <name>Maven Repository - Releases</name>
+    <url>https://raw.github.com/Rise-Vision/mvn-repo/releases</url>
+  </repository>
+  <repository>
+    <id>mvn-repo-snapshots</id>
+    <releases>
+      <enabled>false</enabled>
+    </releases>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+    <name>Maven Repository - Snapshots</name>
+    <url>https://raw.github.com/Rise-Vision/mvn-repo/snapshots</url>
+  </repository>
+</repositories>
+
+<!-- ... -->
+
+<!-- In the <dependencies> section of your project's pom.xml -->
+<dependency>
+  <!-- From our private repo -->
+  <groupId>com.risevision.cors</groupId>
+  <artifactId>hsts-filter</artifactId>
+  <version>1.0.0</version>
+</dependency>
+
+<!-- ... -->
+<!-- In your $HOME/.m2/settings.xml -->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers>
+    <server>
+      <id>mvn-repo-releases</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>token {github auth token}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+
+    <server>
+      <id>mvn-repo-snapshots</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>token {github auth token}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+  </servers>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>
+
+```
+
+* You may need to update the dependency list in your project
+```
+mvn clean test -U
+```

--- a/config/settings.xml
+++ b/config/settings.xml
@@ -1,0 +1,39 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+    http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers>
+    <server>
+      <id>mvn-repo-releases</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>token ${env.GITHUB_TOKEN}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+
+    <server>
+      <id>mvn-repo-snapshots</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>token ${env.GITHUB_TOKEN}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+  </servers>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <appengine.target.version>1.9.63</appengine.target.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <groupId>com.risevision.hsts</groupId>
+  <artifactId>hsts-filter</artifactId>
+  <version>1.0.0</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <appengine.target.version>1.9.63</appengine.target.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>repo</id>
+      <url>git:releases://git@github.com:Rise-Vision/mvn-repo.git</url>
+    </repository>
+    <snapshotRepository>
+      <id>snapshot-repo</id>
+      <url>git:snapshots://git@github.com:Rise-Vision/mvn-repo.git</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>synergian-repo</id>
+      <url>https://raw.github.com/synergian/wagon-git/releases</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <extensions>
+        <extension>
+            <groupId>ar.com.synergian</groupId>
+            <artifactId>wagon-git</artifactId>
+            <version>0.2.5</version>
+        </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>3.7.0</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+           <source>1.8</source>
+           <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <preparationGoals>clean verify</preparationGoals>
+          <goals>deploy</goals>
+          <useReleaseProfile>false</useReleaseProfile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.12.0</version>
+        <configuration>
+          <minimumTokens>100</minimumTokens>
+          <targetJdk>${maven.compiler.source}</targetJdk>
+          <printFailingErrors>true</printFailingErrors>
+          <analysisCache>true</analysisCache>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/com/risevision/hsts/filter/HstsFilter.java
+++ b/src/main/java/com/risevision/hsts/filter/HstsFilter.java
@@ -1,0 +1,39 @@
+package com.risevision.hsts.filter;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class HstsFilter implements Filter {
+
+  static final String HTTPS_SCHEME = "https";
+  static final String HSTS_HEADER = "Strict-Transport-Security";
+  static final String HSTS_ONE_YEAR = "max-age=31536000";
+
+  @Override
+  public void init(FilterConfig config) throws ServletException {}
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+  throws ServletException, IOException {
+    String scheme = request.getScheme();
+
+    if( HTTPS_SCHEME.equals(scheme) ) {
+      HttpServletResponse httpResponse = ( HttpServletResponse )response;
+
+      httpResponse.addHeader( HSTS_HEADER, HSTS_ONE_YEAR );
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy() {}
+
+}

--- a/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
+++ b/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
@@ -1,0 +1,54 @@
+package com.risevision.hsts.filter;
+
+import static com.risevision.hsts.filter.HstsFilter.HSTS_HEADER;
+import static com.risevision.hsts.filter.HstsFilter.HSTS_ONE_YEAR;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class HstsFilterTest {  
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain chain;
+
+  @Before public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void addsHstsHeaderToHttpsRequest()
+  throws IOException, ServletException {
+    given(request.getScheme()).willReturn("https");
+
+    HstsFilter filter = new HstsFilter();
+    filter.doFilter(request, response, chain);
+
+    verify(response).addHeader(HSTS_HEADER, HSTS_ONE_YEAR);
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  public void doesntAddHstsHeaderToHttpRequest()
+  throws IOException, ServletException {
+    given(request.getScheme()).willReturn("http");
+
+    HstsFilter filter = new HstsFilter();
+    filter.doFilter(request, response, chain);
+
+    verifyZeroInteractions(response);
+    verify(chain).doFilter(request, response);
+  }
+
+}


### PR DESCRIPTION
## Description
Adds HSTS header to HTTPS requests.

## Motivation and Context
Change recommended for our backend servers by security audit.

The structure of this project was based on the other *-filter repos.

## How Has This Been Tested?
Manually tested using a local Apps dev environment pointing to core branch: https://github.com/Rise-Vision/core/compare/feature/add-hsts-filter?expand=1

The HSTS header is added succesfully to HTTPS requests as shown here:

![hsts-applied](https://user-images.githubusercontent.com/33162690/70092025-f7a80f80-15e2-11ea-87f1-15a3cc002c20.png)

CCI already deploys this filter to mvn-repo as tested here: https://circleci.com/workflow-run/8889cd9a-27a9-47f8-b599-89cfcbee0e39

Some simple automated unit tests were also created for the filter.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - Deploying this still has no effect on existing systems and builds, until it's used in Core or Store production.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify Support.
