### PR TITLE
Feature/add filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     working_directory: ~/cors-filter
     steps:
       - checkout
+      - run: mvn pmd:pmd
       - run: mvn test
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mvn verify
   <!-- From our private repo -->
   <groupId>com.risevision.hsts</groupId>
   <artifactId>hsts-filter</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 
 <!-- ... -->
@@ -117,3 +117,49 @@ mvn verify
 ```
 mvn clean test -U
 ```
+
+* Add the filter to your WEB-INF/web.xml file, and map the URLs that should point to it:
+
+```xml
+  <filter>
+    <filter-name>HstsFilter</filter-name>
+    <filter-class>com.risevision.hsts.filter.HstsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>HstsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+```
+
+In this basic configuration, the filter adds the HSTS header to any HTTPS 
+request, and never adds headers to HTTP requests.
+
+If there are referrers for which the HSTS header doesn't have to be added, it
+can be specified using the *skip-referrers* init param as follows:
+
+```xml
+  <filter>
+    <filter-name>HstsFilter</filter-name>
+    <filter-class>com.risevision.hsts.filter.HstsFilter</filter-class>
+  </filter>
+    <init-param>
+      <param-name>skip-referrers</param-name>
+      <param-value>
+        rva.risevision.com
+        rva-test.risevision.com
+        *rvaserver2.risevision.com
+        *rvauser.appspot.com
+        *rvauser2.appspot.com
+      </param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>HstsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+```
+
+URLs such as 'rva.risevision.com' are exact HTTP or HTTPS matches;
+while URLs that start with '*' such as '*rvaserver2.appspot.com' can match any HTTP 
+or HTTPS requests that end with rvaserver2.appspot.com ( rvaserver2.appspot.com,
+storage-dot-rvaserver2.appspot.com, storage.rvaserver2.appspot.com, etc. ).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
   <groupId>com.risevision.hsts</groupId>
   <artifactId>hsts-filter</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/risevision/hsts/filter/Globals.java
+++ b/src/main/java/com/risevision/hsts/filter/Globals.java
@@ -1,0 +1,10 @@
+package com.risevision.hsts.filter;
+
+public interface Globals
+{
+
+  String HTTPS_SCHEME = "https";
+  String HSTS_HEADER = "Strict-Transport-Security";
+  String HSTS_ONE_YEAR = "max-age=31536000";
+
+}

--- a/src/main/java/com/risevision/hsts/filter/Globals.java
+++ b/src/main/java/com/risevision/hsts/filter/Globals.java
@@ -6,5 +6,9 @@ public interface Globals
   String HTTPS_SCHEME = "https";
   String HSTS_HEADER = "Strict-Transport-Security";
   String HSTS_ONE_YEAR = "max-age=31536000";
+  String ORIGIN_HEADER = "origin";
+  String REFERER_HEADER = "referer";
+
+  String SKIP_REFERRERS_PARAM = "skip-referrers";
 
 }

--- a/src/main/java/com/risevision/hsts/filter/HstsFilter.java
+++ b/src/main/java/com/risevision/hsts/filter/HstsFilter.java
@@ -3,6 +3,8 @@ package com.risevision.hsts.filter;
 import static com.risevision.hsts.filter.Globals.*;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -13,6 +15,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class HstsFilter implements Filter {
@@ -29,15 +32,48 @@ public class HstsFilter implements Filter {
       .collect(Collectors.toList());
   }
 
+  static String extractServerNameFrom(String referrer) {
+    try {
+      URL url = new URL(referrer);
+ 
+      return url.getHost();
+    } catch (MalformedURLException e) {
+      return null; // invalid URL provided, ignore error
+    }
+  }
+
   @Override
-  public void init(FilterConfig config) throws ServletException {}
+  public void init(FilterConfig config) throws ServletException {
+    String skipReferrersString = config.getInitParameter(SKIP_REFERRERS_PARAM);
+
+    if(skipReferrersString != null)
+      skipReferrers = toServerNameMatcherList(skipReferrersString.trim());
+  }
+
+  private boolean shouldSkipReferrers(ServletRequest request) {
+    if(skipReferrers == null)
+      return false;
+
+    HttpServletRequest httpRequest = (HttpServletRequest)request;
+ 
+    String referrer = httpRequest.getHeader(REFERER_HEADER);
+    if(referrer == null)
+      referrer = httpRequest.getHeader(ORIGIN_HEADER);
+
+    if(referrer == null)
+      return false;
+
+    String serverName = extractServerNameFrom(referrer);
+
+    return skipReferrers.stream().anyMatch(matcher -> matcher.test(serverName));
+  }
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
   throws ServletException, IOException {
     String scheme = request.getScheme();
 
-    if( HTTPS_SCHEME.equals(scheme) ) {
+    if( HTTPS_SCHEME.equals(scheme) && !shouldSkipReferrers(request) ) {
       HttpServletResponse httpResponse = ( HttpServletResponse )response;
 
       httpResponse.addHeader( HSTS_HEADER, HSTS_ONE_YEAR );

--- a/src/main/java/com/risevision/hsts/filter/HstsFilter.java
+++ b/src/main/java/com/risevision/hsts/filter/HstsFilter.java
@@ -1,5 +1,7 @@
 package com.risevision.hsts.filter;
 
+import static com.risevision.hsts.filter.Globals.*;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -11,10 +13,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
 public class HstsFilter implements Filter {
-
-  static final String HTTPS_SCHEME = "https";
-  static final String HSTS_HEADER = "Strict-Transport-Security";
-  static final String HSTS_ONE_YEAR = "max-age=31536000";
 
   @Override
   public void init(FilterConfig config) throws ServletException {}

--- a/src/main/java/com/risevision/hsts/filter/HstsFilter.java
+++ b/src/main/java/com/risevision/hsts/filter/HstsFilter.java
@@ -3,6 +3,9 @@ package com.risevision.hsts.filter;
 import static com.risevision.hsts.filter.Globals.*;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -13,6 +16,18 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
 public class HstsFilter implements Filter {
+
+  private static final Pattern SEPARATOR = Pattern.compile("[\\n\\s]+");
+
+  private List<ServerNameMatcher> skipReferrers = null;
+
+  static List<ServerNameMatcher> toServerNameMatcherList(String text) {
+    return SEPARATOR
+      .splitAsStream(text)
+      .filter(pattern -> pattern.length() > 0)
+      .map(ServerNameMatcher::create)
+      .collect(Collectors.toList());
+  }
 
   @Override
   public void init(FilterConfig config) throws ServletException {}

--- a/src/main/java/com/risevision/hsts/filter/ServerNameMatcher.java
+++ b/src/main/java/com/risevision/hsts/filter/ServerNameMatcher.java
@@ -1,0 +1,37 @@
+package com.risevision.hsts.filter;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class ServerNameMatcher implements Predicate<String> {
+
+  private static final String LITERAL_DOT = "[.]";
+  private static final Pattern DOT_REGEX = Pattern.compile(LITERAL_DOT);
+
+  private static String escapeDots(String text) {
+    return DOT_REGEX.matcher(text).replaceAll(LITERAL_DOT);
+  }
+
+  public static ServerNameMatcher create(String pattern) {
+    String regex;
+
+    if(pattern.startsWith("*"))
+      regex = "[\\w.-]*" + escapeDots(pattern.substring(1));
+    else
+      regex = escapeDots(pattern);
+
+    return new ServerNameMatcher(regex);
+  }
+
+  private final Pattern pattern;
+
+  public ServerNameMatcher(String patternString) {
+    pattern = Pattern.compile(patternString);
+  }
+
+  @Override
+  public boolean test(String origin) {
+    return pattern.matcher(origin).matches();
+  }
+
+}

--- a/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
+++ b/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
@@ -181,4 +181,38 @@ public class HstsFilterTest {
     verify(chain).doFilter(request, response);
   }
 
+  @Test
+  public void doesntAddHstsHeaderToHttpsRequestIfOriginIsSkipped()
+  throws IOException, ServletException {
+    String origin = "http://apps.risevision.com";
+
+    given(request.getScheme()).willReturn("https");
+    given(request.getHeader(ORIGIN_HEADER)).willReturn(origin);
+    given(filterConfig.getInitParameter(SKIP_REFERRERS_PARAM)).willReturn("apps.risevision.com");
+
+    HstsFilter filter = new HstsFilter();
+    filter.init(filterConfig);
+    filter.doFilter(request, response, chain);
+
+    verifyZeroInteractions(response);
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  public void addsHstsHeaderToHttpsRequestIfReferrerIsNotSkipped()
+  throws IOException, ServletException {
+    String referrer = "http://apps.risevision.com";
+
+    given(request.getScheme()).willReturn("https");
+    given(request.getHeader(REFERER_HEADER)).willReturn(referrer);
+    given(filterConfig.getInitParameter(SKIP_REFERRERS_PARAM)).willReturn("www.risevision.com");
+
+    HstsFilter filter = new HstsFilter();
+    filter.init(filterConfig);
+    filter.doFilter(request, response, chain);
+
+    verify(response).addHeader(HSTS_HEADER, HSTS_ONE_YEAR);
+    verify(chain).doFilter(request, response);
+  }
+
 }

--- a/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
+++ b/src/test/java/com/risevision/hsts/filter/HstsFilterTest.java
@@ -1,7 +1,7 @@
 package com.risevision.hsts.filter;
 
-import static com.risevision.hsts.filter.HstsFilter.HSTS_HEADER;
-import static com.risevision.hsts.filter.HstsFilter.HSTS_ONE_YEAR;
+import static com.risevision.hsts.filter.Globals.HSTS_HEADER;
+import static com.risevision.hsts.filter.Globals.HSTS_ONE_YEAR;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/src/test/java/com/risevision/hsts/filter/ServerNameMatcherTest.java
+++ b/src/test/java/com/risevision/hsts/filter/ServerNameMatcherTest.java
@@ -1,0 +1,53 @@
+package com.risevision.hsts.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ServerNameMatcherTest {
+
+  @Test
+  public void testMatchOnFixedServerName() {
+    ServerNameMatcher matcher = ServerNameMatcher.create("rvauser.appspot.com");
+
+    assertTrue(matcher.test("rvauser.appspot.com"));
+  }
+
+  @Test
+  public void testNoMatchOnFixedServerName() {
+    ServerNameMatcher matcher = ServerNameMatcher.create("rvauser.appspot.com");
+
+    assertFalse(matcher.test("rvauser-appspot.com"));
+    assertFalse(matcher.test("rvauser2.appspot.com"));
+    assertFalse(matcher.test("www.appspot.com"));
+  }
+
+  @Test
+  public void testDynamicMatch() {
+    ServerNameMatcher matcher = ServerNameMatcher.create("*.risevision.com");
+
+    assertTrue(matcher.test("apps.risevision.com"));
+    assertTrue(matcher.test("rva.risevision.com"));
+    assertTrue(matcher.test("apps-stage-7.risevision.com"));
+    assertTrue(matcher.test("store-stage-0.risevision.com"));
+  }
+
+  @Test
+  public void testDynamicNoMatch() {
+    ServerNameMatcher matcher = ServerNameMatcher.create("*.risevision.com");
+
+    assertFalse(matcher.test("rvarisevision.com"));
+    assertFalse(matcher.test("apps#stage-7.risevision.com"));
+  }
+
+  @Test
+  public void testDynamicRvaUser2Match() {
+    ServerNameMatcher matcher = ServerNameMatcher.create("*rvauser2.appspot.com");
+
+    assertTrue(matcher.test("rvauser2.appspot.com"));
+    assertTrue(matcher.test("1-07-021.rvauser2.appspot.com"));
+    assertTrue(matcher.test("in-app-test-dot-rvauser2.appspot.com"));
+  }
+
+}


### PR DESCRIPTION
## Description
Add support to filter out by referrer/origin

## Motivation and Context
Analysis for storage server has determined that RVA referrers call storage using HTTP: 
https://docs.google.com/spreadsheets/d/1qbrpf1uxsUeoRSTsYsHk3k6DEkDr2k6mgmhUIQc_8BQ/edit#gid=809648892

So the filter was modified in order to be excluded depending on referrer.

## How Has This Been Tested?
Tested manually on a test server. Different scenarios tested:

HTTP requests add no header, as before:
```bash
$ curl -H 'Referer: http://apache.org' -I http://localhost:8080/test/index.jsp
HTTP/1.1 200 
Set-Cookie: JSESSIONID=8A21A38CAE58CAF523A883C7896FCC31; Path=/test; HttpOnly
Content-Type: text/html;charset=ISO-8859-1
Transfer-Encoding: chunked
Date: Thu, 19 Dec 2019 17:33:59 GMT
```

While HTTPS headers add it always when no skipped referrers are set:
```bash
$ curl -k -H 'Referer: http://apache.org' -I https://localhost:8443/test/index.jsp
HTTP/1.1 200 
Strict-Transport-Security: max-age=31536000
```

Referrer exceptions can be configured as follows:
```xml
    <filter-name>HstsFilter</filter-name>
    <filter-class>com.risevision.hsts.filter.HstsFilter</filter-class>
    <init-param>
      <param-name>skip-referrers</param-name>
      <param-value>
        rva.risevision.com
        rva-test.risevision.com
        *rvaserver2.risevision.com
        *rvauser.appspot.com
        *rvauser2.appspot.com
      </param-value>
    </init-param>
  </filter>
  <filter-mapping>
    <filter-name>HstsFilter</filter-name>
    <url-pattern>/*</url-pattern>
  </filter-mapping>
```

And in this case skipped referrers do not add HSTS header on HTTPS:

```bash
$ curl -k -H 'Referer: http://rva.risevision.com' -I https://localhost:8443/test/index.jsp
HTTP/1.1 200 
Set-Cookie: JSESSIONID=4D53C86C2626AC8AA810041E86D20868; Path=/test; Secure; HttpOnly
Content-Type: text/html;charset=ISO-8859-1
Transfer-Encoding: chunked
Date: Thu, 19 Dec 2019 17:52:09 GMT
```

Same for referrers like  http://rva-test.risevision.com, http://storage.rvaserver2.risevision.com, http://storage-dot-rvaserver2.risevision.com, https://www.rvauser.appspot.com/, http://storage.rvaserver2.risevision.com, with or without path, arguments, using Origin header, HTTP or HTTPS referrer.

Automated tests were also created.

The URL matching logic is similar to the one in CORS filter, but not exactly the same. I didn't consider necessary at this point to put effort into abstracting it to common code.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released once approved, as this doesn't affect production until this version is used by any server build.
     - Readme documentation was updated.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
